### PR TITLE
Add ANTLR 2.7.7 as a dependency of GlueGen

### DIFF
--- a/maven/projects/gluegen/pom.in
+++ b/maven/projects/gluegen/pom.in
@@ -1,5 +1,13 @@
   <!-- gluegen/pom.in -->
 
+  <dependencies>
+    <dependency>
+      <groupId>antlr</groupId>
+      <artifactId>antlr</artifactId>
+      <version>2.7.7</version>
+    </dependency>
+  </dependencies>
+
   <scm>
     <url>http://jogamp.org/git/?p=gluegen.git/</url>
     <connection>scm:git:http://jogamp.org/git/gluegen.git/</connection>


### PR DESCRIPTION
The GlueGen compile-time components depend on ANTLR 2.7.7, and
this fact was never included in the POM files. This issue was
uncovered by @Zubnix' recent work on GlueGen.
